### PR TITLE
LIBFCREPO-339. Only highlight OCR text blocks on hover.

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -139,10 +139,10 @@ $(function() {
             'umd:articleSegment': {
               'strokeColor': 'rgba(255, 255, 255, 0.2)',
               'fillColor': 'green',
-              'fillColorAlpha': 0.1,
+              'fillColorAlpha': 0,
               'hoverColor': 'rgba(255, 255, 255, 0.2)',
               'hoverFillColor': 'green',
-              'hoverFillColorAlpha': 0.4,
+              'hoverFillColorAlpha': 0.2,
               'hideTooltip': true
             },
             'umd:Article': {


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBFCREPO-339