### PR TITLE
LIBHYDRA-90. Remove URL encoding of query param.

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -37,7 +37,7 @@ $(function() {
   var manifestURI = iiifURLPrefix + manifestPcdmID + '/manifest';
   var query = getParamValue('q');
   if (query) {
-    manifestURI += '?q=' + encodeURIComponent(query)
+    manifestURI += '?q=' + query
   }
   // var manifestURI = 'http://iiif-sandbox.lib.umd.edu/manifests/sn83045081/1902-01-15/issue.json';
 


### PR DESCRIPTION
The query param comes encoded from Archelon, so it is being double encoded before being sent to pcdm-manifests app.

https://issues.umd.edu/browse/LIBHYDRA-90